### PR TITLE
Minor changes to client network code

### DIFF
--- a/client/src/net.c
+++ b/client/src/net.c
@@ -78,6 +78,7 @@ int net_connect(const char *hostname, const char *port) {
     /* Try to connect. */
     ret = connect(sockfd, p->ai_addr, p->ai_addrlen);
     if(ret == -1) {
+      close(sockfd);
       perror("connect");
       continue;
     }

--- a/client/src/net.c
+++ b/client/src/net.c
@@ -23,6 +23,7 @@
 #include <pthread.h>
 #include <stdio.h>
 #include <string.h>
+#include <errno.h>
 
 #ifndef _WIN32_
 #  define  __USE_POSIX
@@ -62,7 +63,8 @@ int net_connect(const char *hostname, const char *port) {
   /* Resolve hostname. */
   ret = getaddrinfo(hostname, port, &hints, &info);
   if(ret != 0) {
-    fprintf(stderr, "getaddrinfo: %s\n", gai_strerror(ret));
+    fprintf(stderr, "getaddrinfo: %s\n", 
+        (ret == EAI_SYSTEM) ? strerror(errno): gai_strerror(ret));
     return 1;
   }
   


### PR DESCRIPTION
If connect fails the loop would just create another socket, it should be closed and then a new one opened. Also getaddrinfo() may fail because of system error, in which case errno should be used instead of the return value.
