### PR TITLE
Ignore Binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Generated binaries
+cotitan
+cotitand


### PR DESCRIPTION
The compiled binaries are annoying when they show up in git status as untracked.
